### PR TITLE
Proxy tweak

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.dvsa.testing.lib</groupId>
     <artifactId>active-support</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.1.1</version>
 
     <properties>
         <nexus.releases>https://nexus.olcs.dev-dvsacloud.uk/repository/maven-releases</nexus.releases>
@@ -41,13 +41,6 @@
     </properties>
 
     <build>
-        <extensions>
-            <extension>
-                <groupId>org.springframework.build</groupId>
-                <artifactId>aws-maven</artifactId>
-                <version>5.0.0.RELEASE</version>
-            </extension>
-        </extensions>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -57,6 +50,11 @@
                     <source>1.8</source>
                     <target>1.8</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
         <nexus.releases>https://nexus.olcs.dev-dvsacloud.uk/repository/maven-releases</nexus.releases>
         <annotations.version>24.0.1</annotations.version>
         <autoIt.version>0.2.44</autoIt.version>
-        <aws-java-sdk-s3.version>1.12.429</aws-java-sdk-s3.version>
-        <aws-secrets-manager>1.12.429</aws-secrets-manager>
+        <aws-java-sdk-s3.version>1.12.470</aws-java-sdk-s3.version>
+        <aws-secrets-manager>1.12.468</aws-secrets-manager>
         <aws-sdk-version>1.12.412</aws-sdk-version>
         <dbunit.version>2.7.3</dbunit.version>
         <faker.version>1.0.2</faker.version>
@@ -33,11 +33,11 @@
         <mysql-connector-java.version>8.0.32</mysql-connector-java.version>
         <java-native-access.version>5.12.1</java-native-access.version>
         <rest-assured.version>5.3.0</rest-assured.version>
-        <selenium.version>4.8.3</selenium.version>
+        <selenium.version>4.9.1</selenium.version>
         <slf4j.version>2.20.0</slf4j.version>
         <slf4j-log4j12.version>2.20.0</slf4j-log4j12.version>
         <typesafe.version>1.4.2</typesafe.version>
-        <webdriver-manager.version>5.3.2</webdriver-manager.version>
+        <webdriver-manager.version>5.3.3</webdriver-manager.version>
     </properties>
 
     <build>

--- a/src/main/java/activesupport/driver/Browser.java
+++ b/src/main/java/activesupport/driver/Browser.java
@@ -118,7 +118,7 @@ public class Browser {
                 driver = chrome.driver();
                 break;
             case "chrome-proxy":
-                chrome.getChromeOptions().addArguments(String.valueOf(ProxyConfig.dvsaProxy().setSslProxy(getIpAddress().concat(":"+getPortNumber()))));
+                chrome.getChromeOptions().setProxy(ProxyConfig.dvsaProxy().setHttpProxy(getIpAddress().concat(":"+getPortNumber())));
                 driver = chrome.driver();
                 break;
             case "firefox-proxy":

--- a/src/main/java/activesupport/driver/Browser.java
+++ b/src/main/java/activesupport/driver/Browser.java
@@ -92,7 +92,6 @@ public class Browser {
         return gridURL;
     }
 
-
     private static void whichBrowser(String browserName) throws IllegalBrowserException, MalformedURLException {
         browserName = browserName.toLowerCase().trim();
         ChromeSetUp chrome = new ChromeSetUp();
@@ -118,7 +117,7 @@ public class Browser {
                 driver = chrome.driver();
                 break;
             case "chrome-proxy":
-                chrome.getChromeOptions().setProxy(ProxyConfig.dvsaProxy().setHttpProxy(getIpAddress().concat(":"+getPortNumber())));
+                chrome.getChromeOptions().setProxy(ProxyConfig.dvsaProxy().setSslProxy(getIpAddress().concat(":"+getPortNumber())));
                 driver = chrome.driver();
                 break;
             case "firefox-proxy":

--- a/src/main/java/activesupport/driver/Parallel/ChromeSetUp.java
+++ b/src/main/java/activesupport/driver/Parallel/ChromeSetUp.java
@@ -32,7 +32,6 @@ public class ChromeSetUp {
         if (getBrowserVersion() == null) {
             driver = new ChromeDriver(getChromeOptions());
         } else {
-            chromeOptions.setCapability("proxy",ProxyConfig.dvsaProxy());
             chromeOptions.setPlatformName(getPlatform());
             chromeOptions.setCapability("browser_version", getBrowserVersion());
             driver = new RemoteWebDriver(new URL(hubURL()), getChromeOptions());

--- a/src/main/java/activesupport/driver/Parallel/ChromeSetUp.java
+++ b/src/main/java/activesupport/driver/Parallel/ChromeSetUp.java
@@ -1,6 +1,5 @@
 package activesupport.driver.Parallel;
 
-import activesupport.proxy.ProxyConfig;
 import io.github.bonigarcia.wdm.WebDriverManager;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
@@ -9,6 +8,8 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 
 import static activesupport.driver.Browser.*;
 
@@ -25,10 +26,19 @@ public class ChromeSetUp {
     }
 
     public static WebDriver driver;
+
+    public static List<String> arguments() {
+        List<String> chromeSwitches = new ArrayList<>();
+        chromeSwitches.add("--ignore-certificate-errors");
+        chromeSwitches.add("--allow-running-insecure-content");
+        chromeSwitches.add("--disable-gpu");
+        chromeSwitches.add("--disable-dev-shm-usage");
+        return chromeSwitches;
+    }
     public WebDriver driver() throws MalformedURLException {
         WebDriverManager.chromedriver().setup();
-        chromeOptions.addArguments(ProxyConfig.ignoreCertErrors());
-        chromeOptions.addArguments("--disable-dev-shm-usage");
+        chromeOptions.setAcceptInsecureCerts(true);
+        chromeOptions.addArguments(arguments());
         if (getBrowserVersion() == null) {
             driver = new ChromeDriver(getChromeOptions());
         } else {

--- a/src/main/java/activesupport/driver/Parallel/EdgeSetUp.java
+++ b/src/main/java/activesupport/driver/Parallel/EdgeSetUp.java
@@ -32,10 +32,10 @@ public class EdgeSetUp {
 
     public WebDriver driver() throws MalformedURLException {
         WebDriverManager.edgedriver().setup();
+        edgeOptions.setCapability("proxy",ProxyConfig.dvsaProxy());
         if (getBrowserVersion() == null) {
             driver = new EdgeDriver(edgeOptions);
         } else {
-            edgeOptions.setCapability("proxy",ProxyConfig.dvsaProxy());
             edgeOptions.setPlatformName(getPlatform());
             edgeOptions.setCapability("browser_version", getBrowserVersion());
             driver = new RemoteWebDriver(new URL(hubURL()), edgeOptions);

--- a/src/main/java/activesupport/driver/Parallel/FirefoxSetUp.java
+++ b/src/main/java/activesupport/driver/Parallel/FirefoxSetUp.java
@@ -33,7 +33,6 @@ public class FirefoxSetUp {
         if (getPlatform() == null) {
             driver = new FirefoxDriver(getOptions());
         } else {
-            options.setCapability("proxy",ProxyConfig.dvsaProxy());
             options.setPlatformName(getPlatform());
             options.setCapability("browser_version", getBrowserVersion());
             driver = new RemoteWebDriver(new URL(hubURL()), getOptions());

--- a/src/main/java/activesupport/proxy/ProxyConfig.java
+++ b/src/main/java/activesupport/proxy/ProxyConfig.java
@@ -16,10 +16,7 @@ public class ProxyConfig {
 
     public static Proxy dvsaProxy() {
         Proxy proxy = new Proxy();
-        proxy.setAutodetect(false);
-        proxy.setSslProxy(System.getProperty("httpsProxy"));
         proxy.setHttpProxy(System.getProperty("httpProxy"));
-        proxy.setNoProxy(System.getProperty("noProxy"));
         return proxy;
     }
 }

--- a/src/main/java/activesupport/proxy/ProxyConfig.java
+++ b/src/main/java/activesupport/proxy/ProxyConfig.java
@@ -5,7 +5,9 @@ import org.openqa.selenium.Proxy;
 public class ProxyConfig {
     public static Proxy dvsaProxy() {
         Proxy proxy = new Proxy();
-        proxy.setSslProxy(System.getProperty("httpProxy"));
+        proxy.setHttpProxy(System.getProperty("httpProxy"));
+        proxy.setSslProxy(System.getProperty("httpsProxy"));
+        proxy.setNoProxy(System.getProperty("noProxy"));
         return proxy;
     }
 }

--- a/src/main/java/activesupport/proxy/ProxyConfig.java
+++ b/src/main/java/activesupport/proxy/ProxyConfig.java
@@ -2,21 +2,10 @@ package activesupport.proxy;
 
 import org.openqa.selenium.Proxy;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public class ProxyConfig {
-    public static List<String> ignoreCertErrors() {
-        List<String> chromeSwitches = new ArrayList<>();
-        chromeSwitches.add("--ignore-certificate-errors");
-        chromeSwitches.add("--allow-running-insecure-content");
-        chromeSwitches.add("--disable-gpu");
-        return chromeSwitches;
-    }
-
     public static Proxy dvsaProxy() {
         Proxy proxy = new Proxy();
-        proxy.setHttpProxy(System.getProperty("httpProxy"));
+        proxy.setSslProxy(System.getProperty("httpProxy"));
         return proxy;
     }
 }

--- a/src/test/java/activesupport/browsers/BrowserTest.java
+++ b/src/test/java/activesupport/browsers/BrowserTest.java
@@ -7,7 +7,7 @@ import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.HttpRequest;
 import org.openqa.selenium.devtools.DevTools;
 import org.openqa.selenium.devtools.HasDevTools;
-import org.openqa.selenium.devtools.v110.network.Network;
+import org.openqa.selenium.devtools.v85.network.Network;
 
 import java.util.Optional;
 
@@ -32,6 +32,7 @@ public class BrowserTest {
 
     @Test
     public void chromeTest(){
+        System.out.println(mockServer.isRunning());
         System.setProperty("browser", "chrome");
         Browser.navigate().get(baseURL.concat(resource));
         assertEquals("Browser Test", Browser.navigate().getTitle());
@@ -75,6 +76,7 @@ public class BrowserTest {
                 .respond(
                         response()
                                 .withBody(htmlBody())
+
                 );
     }
 

--- a/src/test/java/activesupport/browsers/BrowserTest.java
+++ b/src/test/java/activesupport/browsers/BrowserTest.java
@@ -32,7 +32,6 @@ public class BrowserTest {
 
     @Test
     public void chromeTest(){
-        System.out.println(mockServer.isRunning());
         System.setProperty("browser", "chrome");
         Browser.navigate().get(baseURL.concat(resource));
         assertEquals("Browser Test", Browser.navigate().getTitle());


### PR DESCRIPTION
## Description

* Changed proxy to use ssl instead of http
* Moved browser arguments from `Proxy class` into `ChromeSetup`
* Changed how proxy was being called in ChromeSetup
* Fixed unit test runner failure when using `mvn clean install or mvn clean deploy`

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
