### PR TITLE
remove marionette flag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.dvsa.testing.lib</groupId>
     <artifactId>active-support</artifactId>
-    <version>2.0.1.2</version>
+    <version>2.0.1.3</version>
 
     <properties>
         <nexus.releases>https://nexus.olcs.dev-dvsacloud.uk/repository/maven-releases</nexus.releases>

--- a/src/main/java/activesupport/driver/Parallel/FirefoxSetUp.java
+++ b/src/main/java/activesupport/driver/Parallel/FirefoxSetUp.java
@@ -29,7 +29,6 @@ public class FirefoxSetUp {
 
     public WebDriver driver() throws MalformedURLException {
         WebDriverManager.firefoxdriver().setup();
-        options.setCapability("marionette", true);
         options.setAcceptInsecureCerts(true);
         if (getPlatform() == null) {
             driver = new FirefoxDriver(getOptions());


### PR DESCRIPTION
## Description

* Removed marionette flag as w3c standards no longer support that protocol

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
