### PR TITLE
fix:revert condition to check for email contents

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.dvsa.testing.lib</groupId>
     <artifactId>active-support</artifactId>
-    <version>2.5.14-SNAPSHOT</version>
+    <version>2.5.14</version>
 
     <properties>
         <annotations.version>24.0.1</annotations.version>

--- a/src/main/java/activesupport/mailPit/MailPit.java
+++ b/src/main/java/activesupport/mailPit/MailPit.java
@@ -130,7 +130,7 @@ public class MailPit {
                         List<Map<String, Object>> messages = jsonPath.getList("messages");
                         for (Map<String, Object> message : messages) {
                             String subject = (String) message.get("Subject");
-                            if (subject != null && subject.matches(emailAddress +" : "+ subjectContains)) {
+                            if (subject != null && subject.contains(subjectContains)) {
                                 String messageId = (String) message.get("ID");
                                 LOGGER.info("Found message ID: {}", messageId);
                                 String rawUrl = String.format("%s/api/v1/message/%s/raw", this.getIp(), messageId);


### PR DESCRIPTION
## Description

* Removing strict match and using contains

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
