### PR TITLE
fix: extract password from Text property in mailpit email to avoid is…

### DIFF
--- a/src/main/java/activesupport/mailPit/MailPit.java
+++ b/src/main/java/activesupport/mailPit/MailPit.java
@@ -100,10 +100,10 @@ public class MailPit {
                                         // Fetch full message details to get the Text property
                                         String messageUrl = String.format("%s/api/v1/message/%s", this.getIp(), messageId);
                                         LOGGER.info("Fetching message details from: {}", messageUrl);
-                                        
+
                                         this.response = RestUtils.get(messageUrl, this.getHeaders());
-                                        String responseBody = this.response.extract().asString();
-                                        JsonPath jsonPath = new JsonPath(responseBody);
+                                        String messageResponseBody = this.response.extract().asString();
+                                        JsonPath messageJsonPath = new JsonPath(messageResponseBody);
                                         String textContent = jsonPath.getString("Text");
                                         
                                         if (textContent != null) {


### PR DESCRIPTION
…sues with some chrs breaking regex

## Description

use a cleaner JSON property that wont contain chrs to break the password match regex


## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
