### PR TITLE
feat: add AI self-healing selector support using AWS Bedrock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,6 +320,13 @@
             <version>${aws-sdk-batch.version}</version>
         </dependency>
 
+        <!-- AWS Bedrock Agent Runtime (v2 SDK) -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>bedrockagentruntime</artifactId>
+            <version>${aws-sdk-batch.version}</version>
+        </dependency>
+
         <!-- ====================================== -->
         <!-- JSON Processing                        -->
         <!-- ====================================== -->

--- a/src/main/java/activesupport/aws/s3/SecretsManager.java
+++ b/src/main/java/activesupport/aws/s3/SecretsManager.java
@@ -69,14 +69,19 @@ public class SecretsManager {
     }
 
     public static String getSecretValue(String secretKey) {
-        if (cache.containsKey(secretKey)) {
-            return cache.get(secretKey);
+        return getSecretValue(secretsId, secretKey);
+    }
+
+    public static String getSecretValue(String secretName, String secretKey) {
+        String cacheKey = secretName + ":" + secretKey;
+        if (cache.containsKey(cacheKey)) {
+            return cache.get(cacheKey);
         }
 
         String secret = null;
 
         GetSecretValueRequest getSecretValueRequest = new GetSecretValueRequest()
-                .withSecretId(secretsId);
+                .withSecretId(secretName);
         GetSecretValueResult getSecretValueResult = null;
 
         try {
@@ -92,8 +97,10 @@ public class SecretsManager {
         if (getSecretValueResult != null && getSecretValueResult.getSecretString() != null) {
             secret = getSecretValueResult.getSecretString();
             JsonObject jsonObject = JsonParser.parseString(secret).getAsJsonObject();
-            secret = jsonObject.get(secretKey).getAsString();
-            cache.put(secretKey, secret);
+            if (jsonObject.has(secretKey)) {
+                secret = jsonObject.get(secretKey).getAsString();
+                cache.put(cacheKey, secret);
+            }
         }
         return secret;
     }

--- a/src/main/java/activesupport/selfhealing/BedrockSelectorService.java
+++ b/src/main/java/activesupport/selfhealing/BedrockSelectorService.java
@@ -1,0 +1,140 @@
+package activesupport.selfhealing;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.bedrockagentruntime.BedrockAgentRuntimeAsyncClient;
+import software.amazon.awssdk.services.bedrockagentruntime.model.InvokeAgentRequest;
+import software.amazon.awssdk.services.bedrockagentruntime.model.InvokeAgentResponseHandler;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+public class BedrockSelectorService {
+
+    private static final Logger LOGGER = LogManager.getLogger(BedrockSelectorService.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private BedrockAgentRuntimeAsyncClient client;
+
+    private BedrockAgentRuntimeAsyncClient getClient() {
+        if (client == null) {
+            client = BedrockAgentRuntimeAsyncClient.builder()
+                    .region(Region.of(SelfHealingConfig.getRegion()))
+                    .build();
+        }
+        return client;
+    }
+
+    public Optional<HealResult> findCorrectedSelector(String brokenSelector, String selectorType, String pageSource) {
+        try {
+            String truncatedDom = truncateDom(pageSource, SelfHealingConfig.getMaxDomLength());
+            String prompt = buildPrompt(brokenSelector, selectorType, truncatedDom);
+
+            LOGGER.info("SELF-HEALING: Querying Bedrock agent for broken {} selector: {}", selectorType, brokenSelector);
+
+            String sessionId = UUID.randomUUID().toString();
+            StringBuilder responseText = new StringBuilder();
+
+            InvokeAgentResponseHandler handler = InvokeAgentResponseHandler.builder()
+                    .onResponse(response -> LOGGER.debug("SELF-HEALING: Agent response received"))
+                    .subscriber(InvokeAgentResponseHandler.Visitor.builder()
+                            .onChunk(chunk -> {
+                                if (chunk.bytes() != null) {
+                                    responseText.append(chunk.bytes().asUtf8String());
+                                }
+                            })
+                            .build())
+                    .onError(error -> LOGGER.error("SELF-HEALING: Agent streaming error", error))
+                    .build();
+
+            CompletableFuture<Void> future = getClient().invokeAgent(
+                    InvokeAgentRequest.builder()
+                            .agentId(SelfHealingConfig.getAgentId())
+                            .agentAliasId(SelfHealingConfig.getAgentAliasId())
+                            .sessionId(sessionId)
+                            .inputText(prompt)
+                            .build(),
+                    handler
+            );
+
+            future.get(30, TimeUnit.SECONDS);
+
+            return parseResponse(responseText.toString());
+
+        } catch (Exception e) {
+            LOGGER.warn("SELF-HEALING: Failed to query Bedrock agent: {}", e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private String buildPrompt(String brokenSelector, String selectorType, String dom) {
+        return String.format(
+                "You are a Selenium selector repair assistant. A %s selector is broken and needs fixing.\n\n"
+                + "BROKEN SELECTOR: %s\n\n"
+                + "RULES:\n"
+                + "1. Analyse the HTML below and find the correct selector for the same target element.\n"
+                + "2. PRESERVE positional indices like [2], [last()], [position()>1] etc. — they exist because "
+                + "multiple elements match and the test targets a specific one (e.g. a visible checkbox vs a hidden input).\n"
+                + "3. The corrected selector MUST target a VISIBLE, INTERACTABLE element — never a type=\"hidden\" input "
+                + "when the original clearly intended a clickable/visible control.\n"
+                + "4. Only fix what is broken (e.g. a typo in an attribute value). Do not restructure or simplify the selector.\n"
+                + "5. Respond ONLY with JSON: {\"selector\": \"...\", \"confidence\": 0.0-1.0, \"reason\": \"...\"}\n\n"
+                + "PAGE HTML:\n%s",
+                selectorType, brokenSelector, dom
+        );
+    }
+
+    private Optional<HealResult> parseResponse(String response) {
+        try {
+            String jsonStr = extractJson(response);
+            JsonNode json = MAPPER.readTree(jsonStr);
+
+            String selector = json.get("selector").asText();
+            double confidence = json.get("confidence").asDouble();
+            String reason = json.has("reason") ? json.get("reason").asText() : "unknown";
+
+            if (selector == null || selector.isBlank()) {
+                LOGGER.warn("SELF-HEALING: Agent returned empty selector");
+                return Optional.empty();
+            }
+
+            LOGGER.info("SELF-HEALING: Agent suggested selector: {} (confidence: {}, reason: {})",
+                    selector, confidence, reason);
+
+            return Optional.of(new HealResult(selector, confidence, reason));
+
+        } catch (Exception e) {
+            LOGGER.warn("SELF-HEALING: Failed to parse agent response: {} | Raw response: {}",
+                    e.getMessage(), response);
+            return Optional.empty();
+        }
+    }
+
+    private String extractJson(String response) {
+        int start = response.indexOf('{');
+        int end = response.lastIndexOf('}');
+        if (start >= 0 && end > start) {
+            return response.substring(start, end + 1);
+        }
+        return response;
+    }
+
+    static String truncateDom(String pageSource, int maxLength) {
+        if (pageSource == null) return "";
+        // Strip script and style content to maximise useful DOM in the context window
+        String cleaned = pageSource
+                .replaceAll("(?s)<script[^>]*>.*?</script>", "")
+                .replaceAll("(?s)<style[^>]*>.*?</style>", "")
+                .replaceAll("\\s{2,}", " ");
+
+        if (cleaned.length() <= maxLength) {
+            return cleaned;
+        }
+        return cleaned.substring(0, maxLength) + "\n<!-- DOM TRUNCATED -->";
+    }
+}

--- a/src/main/java/activesupport/selfhealing/HealResult.java
+++ b/src/main/java/activesupport/selfhealing/HealResult.java
@@ -1,0 +1,31 @@
+package activesupport.selfhealing;
+
+public class HealResult {
+
+    private final String selector;
+    private final double confidence;
+    private final String reason;
+
+    public HealResult(String selector, double confidence, String reason) {
+        this.selector = selector;
+        this.confidence = confidence;
+        this.reason = reason;
+    }
+
+    public String getSelector() {
+        return selector;
+    }
+
+    public double getConfidence() {
+        return confidence;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("HealResult{selector='%s', confidence=%.2f, reason='%s'}", selector, confidence, reason);
+    }
+}

--- a/src/main/java/activesupport/selfhealing/SelfHealingConfig.java
+++ b/src/main/java/activesupport/selfhealing/SelfHealingConfig.java
@@ -8,7 +8,7 @@ public final class SelfHealingConfig {
 
     private static final Logger LOGGER = LogManager.getLogger(SelfHealingConfig.class);
     private static final String PREFIX = "selfHealing.";
-    private static final String DEFAULT_SECRET_NAME = "vol-functional-tests/self-healing";
+    private static final String DEFAULT_SECRET_NAME = "vol-functional-tests/bedrock";
 
     private SelfHealingConfig() {
     }
@@ -22,11 +22,11 @@ public final class SelfHealingConfig {
     }
 
     public static String getAgentId() {
-        return getConfigValue("agentId");
+        return getConfigValue("selfHeal_agentId");
     }
 
     public static String getAgentAliasId() {
-        return getConfigValue("agentAliasId");
+        return getConfigValue("selfHealth_agentAliasId");
     }
 
     public static int getMaxDomLength() {

--- a/src/main/java/activesupport/selfhealing/SelfHealingConfig.java
+++ b/src/main/java/activesupport/selfhealing/SelfHealingConfig.java
@@ -1,25 +1,14 @@
 package activesupport.selfhealing;
 
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.regions.Regions;
-import com.amazonaws.services.secretsmanager.AWSSecretsManager;
-import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
-import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
-import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import activesupport.aws.s3.SecretsManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 public final class SelfHealingConfig {
 
     private static final Logger LOGGER = LogManager.getLogger(SelfHealingConfig.class);
     private static final String PREFIX = "selfHealing.";
     private static final String DEFAULT_SECRET_NAME = "vol-functional-tests/self-healing";
-    private static final Map<String, String> secretCache = new ConcurrentHashMap<>();
 
     private SelfHealingConfig() {
     }
@@ -56,36 +45,12 @@ public final class SelfHealingConfig {
         if (prop != null && !prop.isBlank()) {
             return prop;
         }
-        return getSecretValue(key);
-    }
-
-    private static String getSecretValue(String key) {
-        if (secretCache.containsKey(key)) {
-            return secretCache.get(key);
-        }
-
         try {
             String secretName = System.getProperty(PREFIX + "secretName", DEFAULT_SECRET_NAME);
-            AWSSecretsManager client = AWSSecretsManagerClientBuilder.standard()
-                    .withCredentials(new DefaultAWSCredentialsProviderChain())
-                    .withRegion(Regions.EU_WEST_1)
-                    .build();
-
-            GetSecretValueResult result = client.getSecretValue(
-                    new GetSecretValueRequest().withSecretId(secretName));
-
-            if (result.getSecretString() != null) {
-                JsonObject json = JsonParser.parseString(result.getSecretString()).getAsJsonObject();
-                if (json.has(key)) {
-                    String value = json.get(key).getAsString();
-                    secretCache.put(key, value);
-                    return value;
-                }
-            }
+            return SecretsManager.getSecretValue(secretName, key);
         } catch (Exception e) {
             LOGGER.warn("SELF-HEALING: Failed to fetch '{}' from Secrets Manager: {}", key, e.getMessage());
+            return "";
         }
-
-        return "";
     }
 }

--- a/src/main/java/activesupport/selfhealing/SelfHealingConfig.java
+++ b/src/main/java/activesupport/selfhealing/SelfHealingConfig.java
@@ -1,0 +1,91 @@
+package activesupport.selfhealing;
+
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.secretsmanager.AWSSecretsManager;
+import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
+import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
+import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class SelfHealingConfig {
+
+    private static final Logger LOGGER = LogManager.getLogger(SelfHealingConfig.class);
+    private static final String PREFIX = "selfHealing.";
+    private static final String DEFAULT_SECRET_NAME = "vol-functional-tests/self-healing";
+    private static final Map<String, String> secretCache = new ConcurrentHashMap<>();
+
+    private SelfHealingConfig() {
+    }
+
+    public static boolean isEnabled() {
+        return Boolean.parseBoolean(System.getProperty(PREFIX + "enabled", "false"));
+    }
+
+    public static String getRegion() {
+        return System.getProperty(PREFIX + "region", "eu-west-1");
+    }
+
+    public static String getAgentId() {
+        return getConfigValue("agentId");
+    }
+
+    public static String getAgentAliasId() {
+        return getConfigValue("agentAliasId");
+    }
+
+    public static int getMaxDomLength() {
+        return Integer.parseInt(System.getProperty(PREFIX + "maxDomLength", "50000"));
+    }
+
+    public static double getMinConfidence() {
+        return Double.parseDouble(System.getProperty(PREFIX + "minConfidence", "0.5"));
+    }
+
+    /**
+     * Resolves a config value: system property first, then AWS Secrets Manager.
+     */
+    private static String getConfigValue(String key) {
+        String prop = System.getProperty(PREFIX + key);
+        if (prop != null && !prop.isBlank()) {
+            return prop;
+        }
+        return getSecretValue(key);
+    }
+
+    private static String getSecretValue(String key) {
+        if (secretCache.containsKey(key)) {
+            return secretCache.get(key);
+        }
+
+        try {
+            String secretName = System.getProperty(PREFIX + "secretName", DEFAULT_SECRET_NAME);
+            AWSSecretsManager client = AWSSecretsManagerClientBuilder.standard()
+                    .withCredentials(new DefaultAWSCredentialsProviderChain())
+                    .withRegion(Regions.EU_WEST_1)
+                    .build();
+
+            GetSecretValueResult result = client.getSecretValue(
+                    new GetSecretValueRequest().withSecretId(secretName));
+
+            if (result.getSecretString() != null) {
+                JsonObject json = JsonParser.parseString(result.getSecretString()).getAsJsonObject();
+                if (json.has(key)) {
+                    String value = json.get(key).getAsString();
+                    secretCache.put(key, value);
+                    return value;
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.warn("SELF-HEALING: Failed to fetch '{}' from Secrets Manager: {}", key, e.getMessage());
+        }
+
+        return "";
+    }
+}

--- a/src/main/java/activesupport/selfhealing/SelfHealingElementLocator.java
+++ b/src/main/java/activesupport/selfhealing/SelfHealingElementLocator.java
@@ -1,0 +1,125 @@
+package activesupport.selfhealing;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.util.Optional;
+
+public class SelfHealingElementLocator {
+
+    private static final Logger LOGGER = LogManager.getLogger(SelfHealingElementLocator.class);
+    private static final BedrockSelectorService bedrockService = new BedrockSelectorService();
+
+    private SelfHealingElementLocator() {
+    }
+
+    /**
+     * Attempts to heal a broken selector by analysing the current page DOM with AI.
+     * Returns the healed WebElement if successful, or empty if healing is disabled,
+     * fails, or the confidence is too low.
+     *
+     * @param driver          the active WebDriver instance
+     * @param brokenSelector  the selector string that failed
+     * @param selectorType    the type of selector (CSS, XPATH, ID, etc.)
+     * @return Optional containing the found WebElement if healing succeeded
+     */
+    public static Optional<WebElement> heal(WebDriver driver, String brokenSelector, String selectorType) {
+        if (!SelfHealingConfig.isEnabled()) {
+            return Optional.empty();
+        }
+
+        try {
+            LOGGER.warn("SELF-HEALING: Attempting to heal broken {} selector: {}", selectorType, brokenSelector);
+
+            String pageSource = driver.getPageSource();
+            Optional<HealResult> result = bedrockService.findCorrectedSelector(brokenSelector, selectorType, pageSource);
+
+            if (result.isEmpty()) {
+                LOGGER.warn("SELF-HEALING: Agent could not find a replacement selector");
+                return Optional.empty();
+            }
+
+            HealResult heal = result.get();
+
+            if (heal.getConfidence() < SelfHealingConfig.getMinConfidence()) {
+                LOGGER.warn("SELF-HEALING: Confidence too low ({}) for selector: {}",
+                        heal.getConfidence(), heal.getSelector());
+                return Optional.empty();
+            }
+
+            By healedBy = toBy(heal.getSelector(), selectorType);
+            WebElement element = driver.findElement(healedBy);
+
+            // If the healed element is a hidden input, look for a visible sibling with the same name
+            if (!element.isDisplayed()) {
+                LOGGER.warn("SELF-HEALING: Healed element is not displayed, searching for visible alternative");
+                java.util.List<WebElement> candidates = driver.findElements(healedBy);
+                Optional<WebElement> visible = candidates.stream()
+                        .filter(WebElement::isDisplayed)
+                        .findFirst();
+                if (visible.isPresent()) {
+                    element = visible.get();
+                    LOGGER.info("SELF-HEALING: Found visible alternative (element {} of {})",
+                            candidates.indexOf(element) + 1, candidates.size());
+                } else {
+                    LOGGER.warn("SELF-HEALING: No visible alternative found — using original healed element");
+                }
+            }
+
+            LOGGER.warn(
+                    "\n╔══════════════════════════════════════════════════════════════╗\n" +
+                    "║  SELF-HEALED SELECTOR                                        ║\n" +
+                    "╠══════════════════════════════════════════════════════════════╣\n" +
+                    "║  Type:       {}\n" +
+                    "║  Broken:     {}\n" +
+                    "║  Healed:     {}\n" +
+                    "║  Confidence: {}\n" +
+                    "║  Reason:     {}\n" +
+                    "║  Page:       {}\n" +
+                    "╠══════════════════════════════════════════════════════════════╣\n" +
+                    "║  ⚠  UPDATE YOUR TEST CODE WITH THE HEALED SELECTOR          ║\n" +
+                    "╚══════════════════════════════════════════════════════════════╝",
+                    selectorType, brokenSelector, heal.getSelector(),
+                    heal.getConfidence(), heal.getReason(), driver.getCurrentUrl()
+            );
+
+            return Optional.of(element);
+
+        } catch (Exception e) {
+            LOGGER.warn("SELF-HEALING: Healing attempt failed: {}", e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Converts the healed selector string to a Selenium By locator.
+     * Auto-detects the format returned by the AI agent rather than
+     * blindly trusting the original selectorType — the agent may return
+     * a CSS selector (#id) even when the broken selector was type ID.
+     */
+    static By toBy(String selector, String selectorType) {
+        // Agent returned an XPath expression
+        if (selector.startsWith("//") || selector.startsWith("(//")) {
+            return By.xpath(selector);
+        }
+
+        // Agent returned a CSS #id selector — use cssSelector, not By.id
+        if (selector.startsWith("#") || selector.startsWith(".") || selector.contains("[")) {
+            return By.cssSelector(selector);
+        }
+
+        // No prefix detected — fall back to the original type
+        return switch (selectorType.toUpperCase()) {
+            case "CSS" -> By.cssSelector(selector);
+            case "XPATH" -> By.xpath(selector);
+            case "ID" -> By.id(selector);
+            case "NAME" -> By.name(selector);
+            case "LINKTEXT" -> By.linkText(selector);
+            case "PARTIALLINKTEXT" -> By.partialLinkText(selector);
+            default -> By.cssSelector(selector);
+        };
+    }
+}

--- a/src/test/java/activesupport/selfhealing/BedrockSelectorServiceTest.java
+++ b/src/test/java/activesupport/selfhealing/BedrockSelectorServiceTest.java
@@ -1,0 +1,51 @@
+package activesupport.selfhealing;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BedrockSelectorServiceTest {
+
+    @Test
+    void truncateDomStripsScriptTags() {
+        String html = "<html><body><script>var x = 1;</script><div id='main'>Hello</div></body></html>";
+        String result = BedrockSelectorService.truncateDom(html, 50000);
+        assertFalse(result.contains("<script>"));
+        assertTrue(result.contains("<div id='main'>Hello</div>"));
+    }
+
+    @Test
+    void truncateDomStripsStyleTags() {
+        String html = "<html><head><style>.x { color: red; }</style></head><body><p>Content</p></body></html>";
+        String result = BedrockSelectorService.truncateDom(html, 50000);
+        assertFalse(result.contains("<style>"));
+        assertTrue(result.contains("<p>Content</p>"));
+    }
+
+    @Test
+    void truncateDomRespectsMaxLength() {
+        String html = "<div>" + "a".repeat(100000) + "</div>";
+        String result = BedrockSelectorService.truncateDom(html, 1000);
+        assertTrue(result.length() <= 1000 + "<!-- DOM TRUNCATED -->".length() + 1);
+        assertTrue(result.endsWith("<!-- DOM TRUNCATED -->"));
+    }
+
+    @Test
+    void truncateDomHandlesNull() {
+        assertEquals("", BedrockSelectorService.truncateDom(null, 50000));
+    }
+
+    @Test
+    void truncateDomCollapsesWhitespace() {
+        String html = "<div>   \n\n   <p>text</p>   \n   </div>";
+        String result = BedrockSelectorService.truncateDom(html, 50000);
+        assertFalse(result.contains("   "));
+    }
+
+    @Test
+    void truncateDomReturnFullDomWhenUnderLimit() {
+        String html = "<div><p>Short content</p></div>";
+        String result = BedrockSelectorService.truncateDom(html, 50000);
+        assertFalse(result.contains("TRUNCATED"));
+    }
+}

--- a/src/test/java/activesupport/selfhealing/SelfHealingConfigTest.java
+++ b/src/test/java/activesupport/selfhealing/SelfHealingConfigTest.java
@@ -1,0 +1,72 @@
+package activesupport.selfhealing;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SelfHealingConfigTest {
+
+    @Test
+    void isDisabledByDefault() {
+        System.clearProperty("selfHealing.enabled");
+        assertFalse(SelfHealingConfig.isEnabled());
+    }
+
+    @Test
+    void canBeEnabledViaSystemProperty() {
+        System.setProperty("selfHealing.enabled", "true");
+        try {
+            assertTrue(SelfHealingConfig.isEnabled());
+        } finally {
+            System.clearProperty("selfHealing.enabled");
+        }
+    }
+
+    @Test
+    void defaultRegionIsEuWest1() {
+        System.clearProperty("selfHealing.region");
+        assertEquals("eu-west-1", SelfHealingConfig.getRegion());
+    }
+
+    @Test
+    void agentIdCanBeSetViaSystemProperty() {
+        System.setProperty("selfHealing.agentId", "TEST_AGENT");
+        try {
+            assertEquals("TEST_AGENT", SelfHealingConfig.getAgentId());
+        } finally {
+            System.clearProperty("selfHealing.agentId");
+        }
+    }
+
+    @Test
+    void agentAliasIdCanBeSetViaSystemProperty() {
+        System.setProperty("selfHealing.agentAliasId", "TEST_ALIAS");
+        try {
+            assertEquals("TEST_ALIAS", SelfHealingConfig.getAgentAliasId());
+        } finally {
+            System.clearProperty("selfHealing.agentAliasId");
+        }
+    }
+
+    @Test
+    void defaultMaxDomLengthIs50000() {
+        System.clearProperty("selfHealing.maxDomLength");
+        assertEquals(50000, SelfHealingConfig.getMaxDomLength());
+    }
+
+    @Test
+    void defaultMinConfidenceIs05() {
+        System.clearProperty("selfHealing.minConfidence");
+        assertEquals(0.5, SelfHealingConfig.getMinConfidence());
+    }
+
+    @Test
+    void regionCanBeOverridden() {
+        System.setProperty("selfHealing.region", "us-east-1");
+        try {
+            assertEquals("us-east-1", SelfHealingConfig.getRegion());
+        } finally {
+            System.clearProperty("selfHealing.region");
+        }
+    }
+}

--- a/src/test/java/activesupport/selfhealing/SelfHealingConfigTest.java
+++ b/src/test/java/activesupport/selfhealing/SelfHealingConfigTest.java
@@ -30,21 +30,21 @@ class SelfHealingConfigTest {
 
     @Test
     void agentIdCanBeSetViaSystemProperty() {
-        System.setProperty("selfHealing.agentId", "TEST_AGENT");
+        System.setProperty("selfHealing.selfHeal_agentId", "TEST_AGENT");
         try {
             assertEquals("TEST_AGENT", SelfHealingConfig.getAgentId());
         } finally {
-            System.clearProperty("selfHealing.agentId");
+            System.clearProperty("selfHealing.selfHeal_agentId");
         }
     }
 
     @Test
     void agentAliasIdCanBeSetViaSystemProperty() {
-        System.setProperty("selfHealing.agentAliasId", "TEST_ALIAS");
+        System.setProperty("selfHealing.selfHealth_agentAliasId", "TEST_ALIAS");
         try {
             assertEquals("TEST_ALIAS", SelfHealingConfig.getAgentAliasId());
         } finally {
-            System.clearProperty("selfHealing.agentAliasId");
+            System.clearProperty("selfHealing.selfHealth_agentAliasId");
         }
     }
 

--- a/src/test/java/activesupport/selfhealing/SelfHealingElementLocatorTest.java
+++ b/src/test/java/activesupport/selfhealing/SelfHealingElementLocatorTest.java
@@ -1,0 +1,82 @@
+package activesupport.selfhealing;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SelfHealingElementLocatorTest {
+
+    @AfterEach
+    void cleanup() {
+        System.clearProperty("selfHealing.enabled");
+    }
+
+    @Test
+    void healReturnsEmptyWhenDisabled() {
+        System.setProperty("selfHealing.enabled", "false");
+        var result = SelfHealingElementLocator.heal(null, "//broken", "XPATH");
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void healReturnsEmptyWhenEnabledButDriverIsNull() {
+        System.setProperty("selfHealing.enabled", "true");
+        // Passing null driver should be handled gracefully
+        var result = SelfHealingElementLocator.heal(null, "//broken", "XPATH");
+        assertTrue(result.isEmpty());
+    }
+
+    // --- toBy auto-detection tests ---
+
+    @Test
+    void toByDetectsXpathFromDoubleSlash() {
+        By result = SelfHealingElementLocator.toBy("//input[@id='foo']", "ID");
+        assertEquals(By.xpath("//input[@id='foo']"), result);
+    }
+
+    @Test
+    void toByDetectsXpathFromParenthesisDoubleSlash() {
+        By result = SelfHealingElementLocator.toBy("(//div)[1]", "CSS");
+        assertEquals(By.xpath("(//div)[1]"), result);
+    }
+
+    @Test
+    void toByDetectsCssSelectorFromHash() {
+        // Agent returns #declarationRead for an ID type — should use cssSelector, not By.id
+        By result = SelfHealingElementLocator.toBy("#declarationRead", "ID");
+        assertEquals(By.cssSelector("#declarationRead"), result);
+    }
+
+    @Test
+    void toByDetectsCssSelectorFromDot() {
+        By result = SelfHealingElementLocator.toBy(".govuk-button", "XPATH");
+        assertEquals(By.cssSelector(".govuk-button"), result);
+    }
+
+    @Test
+    void toByDetectsCssSelectorFromAttributeBracket() {
+        By result = SelfHealingElementLocator.toBy("input[name='email']", "ID");
+        assertEquals(By.cssSelector("input[name='email']"), result);
+    }
+
+    @Test
+    void toByFallsBackToOriginalTypeForPlainId() {
+        // Plain ID string with no CSS/XPath markers — should use By.id
+        By result = SelfHealingElementLocator.toBy("declarationRead", "ID");
+        assertEquals(By.id("declarationRead"), result);
+    }
+
+    @Test
+    void toByFallsBackToOriginalTypeForPlainName() {
+        By result = SelfHealingElementLocator.toBy("email", "NAME");
+        assertEquals(By.name("email"), result);
+    }
+
+    @Test
+    void toByFallsBackToLinkText() {
+        By result = SelfHealingElementLocator.toBy("Sign in", "LINKTEXT");
+        assertEquals(By.linkText("Sign in"), result);
+    }
+}


### PR DESCRIPTION
Adds runtime self-healing for broken Selenium selectors via AWS Bedrock
Agent (Amazon Nova Lite). When a selector fails, the system sends the
broken selector and page DOM to the AI agent which suggests a corrected
selector with confidence scoring.

- BedrockSelectorService: async streaming client for Bedrock Agent
- SelfHealingElementLocator: heal logic with auto-detect selector format
- SelfHealingConfig: feature flags, Secrets Manager for agent credentials
- Post-heal visibility fallback for hidden elements
- Unit tests (24 passing)

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
