### PR TITLE
fix: exclude transitive netty from AWS batch and bedrock dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,6 +320,12 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>batch</artifactId>
             <version>${aws-sdk-batch.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- AWS Bedrock Agent Runtime (v2 SDK) -->
@@ -327,6 +333,12 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>bedrockagentruntime</artifactId>
             <version>${aws-sdk-batch.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- ====================================== -->


### PR DESCRIPTION
Excludes io.netty:* from software.amazon.awssdk:batch and bedrockagentruntime to resolve SNYK-JAVA-IONETTY-16438929 (netty-codec-http2@4.1.132.Final vulnerability).

The AWS SDK uses netty internally for its async HTTP client but active-support uses the apache-client, so netty is not needed.

## Description

<!--
Include a summary of the change here.
-->

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
