### PR TITLE
fix: update vol-uri-constructor to 2.4.0 for correct local URLs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <jacob.version>1.14.3</jacob.version>
 
         <!-- DVSA Internal -->
-        <uri-constructor.version>2.3.0</uri-constructor.version>
+        <uri-constructor.version>2.4.0</uri-constructor.version>
 
         <!-- Web Testing & BDD -->
         <jsoup.version>1.18.3</jsoup.version>


### PR DESCRIPTION
The v2.3.0 JAR uses Docker service names (olcs-backend, olcs-selfserve) for LOCAL env which only work from inside Docker containers. The v2.4.0 version uses the correct proxy hostnames (api.local.olcs.dev-dvsacloud.uk, ssweb.local.olcs.dev-dvsacloud.uk) enabling tests to run from the host.

## Description

<!--
Include a summary of the change here.
-->

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
