### PR TITLE
fix: exclude transitive netty from aws-java-sdk to resolve vulnerabil…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,6 +299,12 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
             <version>${aws-java-sdk-s3.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- AWS S3 -->


### PR DESCRIPTION
…ities

Excludes io.netty:* from aws-java-sdk (v1) dependency to prevent transitive netty-codec@4.1.132.Final being pulled via aws-java-sdk-kinesisvideo. The managed netty version (4.2.13.Final) will be used instead, resolving SNYK-JAVA-IONETTY-16438322 and SNYK-JAVA-IONETTY-16438930.

## Description

<!--
Include a summary of the change here.
-->

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
