### PR TITLE
fix: upgrade httpclient5 from 5.6.1 to 5.6.2 to address CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <jansi.version>2.4.1</jansi.version>
 
         <!-- HTTP & Networking -->
-        <httpclient.version>5.6.1</httpclient.version>
+        <httpclient.version>5.6.2</httpclient.version>
         <netty.version>4.2.15.Final</netty.version>
 
         <!-- Data & File Processing -->


### PR DESCRIPTION
Fixes SNYK-JAVA-ORGAPACHEHTTPCOMPONENTSCORE5-17817217 and SNYK-JAVA-ORGAPACHEHTTPCOMPONENTSCORE5-17817218 - Allocation of Resources Without Limits or Throttling in httpcore5-h2@5.4

## Description

<!--
Include a summary of the change here.
-->

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
